### PR TITLE
Fix bad whatis entry in manpage

### DIFF
--- a/src/include/libocxl.h
+++ b/src/include/libocxl.h
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * @file libocxl.h
+ * @brief library functions to implement userspace drivers for OpenCAPI accelerators
+ */
+
 #ifndef _LIBOCXL_H
 #define _LIBOCXL_H
 


### PR DESCRIPTION
During Debian packaging lintian complains about the NAME section of the man
page which doesn't provide a brief description which is parsed to generate a
database for commands such as apropos and whatis.

Maybe there are better way to do but this seems to work and produces necessary
and sufficient output :
```
$ diff -baupr  old/docs/man/ new/docs/man/
diff -baupr old/docs/man/man3/libocxl.h.3 new/docs/man/man3/libocxl.h.3
--- old/docs/man/man3/libocxl.h.3	2018-04-27 10:05:02.718531541 +0200
+++ new/docs/man/man3/libocxl.h.3	2018-04-27 10:29:42.821057863 +0200
@@ -2,7 +2,8 @@
 .ad l
 .nh
 .SH NAME
-libocxl.h
+libocxl.h \- library functions to implement userspace drivers for OpenCAPI accelerators
+
 .SH SYNOPSIS
 .br
 .PP
@@ -231,6 +232,11 @@ libocxl.h
 .br
 .RI "Convert endianess and write a 64-bit value to an AFU's MMIO region\&. "
 .in -1c
+.SH "Detailed Description"
+.PP
+library functions to implement userspace drivers for OpenCAPI accelerators
+
+
 .SH "Data Structure Documentation"
 .PP
 .SH "struct ocxl_identifier"
```