### PR TITLE
Fix build with glibc 2.19 and older

### DIFF
--- a/src/mmio.c
+++ b/src/mmio.c
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// Needed for le32toh() and friends when building against glibc version < 2.20
+#define _BSD_SOURCE
+
 #include "libocxl_internal.h"
 #include "sys/mman.h"
 #include "errno.h"


### PR DESCRIPTION
According to the endian(3) manual page:

Feature Test Macro Requirements for glibc (see feature_test_macros(7)):

    htobe16(),   htole16(),  be16toh(),  le16toh(),  htobe32(),  htole32(),
    be32toh(), le32toh(), htobe64(), htole64(), be64toh(), le64toh():
        Since glibc 2.19:
            _DEFAULT_SOURCE
        In glibc up to and including 2.19:
            _BSD_SOURCE

and feature_test_macros(7):

    Since  glibc  2.20,  this  macro is deprecated.  It now has the
    same effect as defining _DEFAULT_SOURCE, but generates  a  compile-
    time  warning  (unless  _DEFAULT_SOURCE  is also defined).
    Use _DEFAULT_SOURCE  instead.   To  allow  code  that  requires
    _BSD_SOURCE  in  glibc  2.19 and earlier and _DEFAULT_SOURCE in
    glibc 2.20 and later to compile without warnings,  define  both
    _BSD_SOURCE and _DEFAULT_SOURCE.


_DEFAULT_SOURCE is defined by default, so we just need to define
_BSD_SOURCE.

Signed-off-by: Greg Kurz <groug@kaod.org>