### PR TITLE
ocxl_afp3: update offset mask to cover full buffer by default

### DIFF
--- a/afutests/afp/ocxl_afp3.c
+++ b/afutests/afp/ocxl_afp3.c
@@ -64,7 +64,7 @@ static int npu_ld = 0;
 static int npu_st = 0;
 static uint16_t numLoops = 3;
 static uint16_t waitTime = 2;
-static uint64_t offsetmask = 0x7f;   // Default to 512kB
+static uint64_t offsetmask = 0x3FF;   // Default to 4MB
 
 static uint64_t enableAfu   = 0x8000000000000000;
 static uint64_t disableAfu  = 0x0000000000000000;


### PR DESCRIPTION
Signed-off-by: Frederic Barrat <fbarrat@linux.ibm.com>