### PR TITLE
Turn afutests README usage text into code block.

### DIFF
--- a/afutests/afp/README.md
+++ b/afutests/afp/README.md
@@ -14,31 +14,32 @@ Usage
 
     $ ../../afuobj/ocxl_afp3
 
-Usage: ocxl_afp3 [ options ]
-    --tags_ld     Number of tags for loads.  Default=0
-    --tags_st     Number of tags for stores.  Default=0
-                  0 -   0 tags (disabled)
-                  1 -   1 tag
-                  2 -   2 tags
-                  3 -   4 tags
-                  4 -  16 tags
-                  5 -  64 tags
-                  6 - 256 tags
-                  7 - 512 tags
-    --size_ld     Data size, in Bytes, for loads.
-                  Supported values: 64, 128, 256.  Default=128
-    --size_st     Data size, in Bytes, for stores.
-                  Supported values: 64, 128, 256.  Default=128
-    --npu_ld      Use rd_wnitc.n for loads.  Default is rd_wnitc
-    --npu_st      Use dma_w.n for stores.  Default is dma_w
-    --num         Number of times to check perf counts.  Default is 3
-    --wait        Amount of seconds to wait between perf count reads.
-                  Default is 2
-    --prefetch    Initialize buffer memory
-    --offsetmask  Determines how much of buffer to use.
-                  Default 512kB.  Valid Range: 4K-512M.
-                  Format: NumberLetter, e.g. 4K, 512K, 1M, 512M
-    --timeout     Default=1 seconds
-    --verbose     Verbose output
-    --help        Print this message
-
+```
+    Usage: ocxl_afp3 [ options ]
+        --tags_ld     Number of tags for loads.  Default=0
+        --tags_st     Number of tags for stores.  Default=0
+                      0 -   0 tags (disabled)
+                      1 -   1 tag
+                      2 -   2 tags
+                      3 -   4 tags
+                      4 -  16 tags
+                      5 -  64 tags
+                      6 - 256 tags
+                      7 - 512 tags
+        --size_ld     Data size, in Bytes, for loads.
+                      Supported values: 64, 128, 256.  Default=128
+        --size_st     Data size, in Bytes, for stores.
+                      Supported values: 64, 128, 256.  Default=128
+        --npu_ld      Use rd_wnitc.n for loads.  Default is rd_wnitc
+        --npu_st      Use dma_w.n for stores.  Default is dma_w
+        --num         Number of times to check perf counts.  Default is 3
+        --wait        Amount of seconds to wait between perf count reads.
+                      Default is 2
+        --prefetch    Initialize buffer memory
+        --offsetmask  Determines how much of buffer to use.
+                      Default 512kB.  Valid Range: 4K-512M.
+                      Format: NumberLetter, e.g. 4K, 512K, 1M, 512M
+        --timeout     Default=1 seconds
+        --verbose     Verbose output
+        --help        Print this message
+```

--- a/afutests/memcpy/README.md
+++ b/afutests/memcpy/README.md
@@ -16,6 +16,7 @@ Usage
     $ ../../afuobj/ocxl_memcpy -A  # Test memcpy AFU atomic compare and swap
     $ ../../afuobj/ocxl_memcpy -a  # Test memcpy AFU increment
 
+```
     Usage: ocxl_memcpy [ options ]
     Options:
         -A            Run the atomic compare and swap test
@@ -27,4 +28,4 @@ Usage
         -r            Reallocate the destination buffer in between 2 loops
         -s <bufsize>  Copy this number of bytes (default 2048)
         -t <timeout>  Seconds to wait for the AFU to signal completion
-
+```


### PR DESCRIPTION
This fixes issue #24.

Signed-off-by: Philippe Bergheaud <felix@linux.ibm.com>