### PR TITLE
irq: Print out errno when irq allocation fails

### DIFF
--- a/src/irq.c
+++ b/src/irq.c
@@ -112,13 +112,13 @@ static ocxl_err irq_allocate(ocxl_afu *afu, ocxl_irq *irq, void *info)
 
 	int rc = ioctl(afu->fd, OCXL_IOCTL_IRQ_ALLOC, &irq->event.irq_offset);
 	if (rc) {
-		errmsg(afu, ret, "Could not allocate IRQ in kernel: %d", rc);
+		errmsg(afu, ret, "Could not allocate IRQ in kernel: %d: '%s'", errno, strerror(errno));
 		goto errend;
 	}
 
 	rc = ioctl(afu->fd, OCXL_IOCTL_IRQ_SET_FD, &irq->event);
 	if (rc) {
-		errmsg(afu, ret, "Could not set event descriptor in kernel: %d", rc);
+		errmsg(afu, ret, "Could not set event descriptor in kernel: %d: '%s'", errno, strerror(errno));
 		goto errend;
 	}
 


### PR DESCRIPTION
When ioctl() fails it always returns -1 and it puts the actual error in
errno.

Signed-off-by: Greg Kurz <groug@kaod.org>