### PR TITLE
ocxl_memcpy: Add memory barrier

### DIFF
--- a/afutests/memcpy/ocxl_memcpy.c
+++ b/afutests/memcpy/ocxl_memcpy.c
@@ -584,6 +584,14 @@ int test_afu_memcpy(struct memcpy_test_args *args)
 			LOG_ERR(pid, "unexpected status 0x%x for wake_host_thread\n", last_we->status);
 			goto err_status;
 		}
+
+		/*
+		 * The memory barrier is to avoid instructions
+		 * re-ordering and make sure no output addresses are
+		 * read before the work element status is complete
+		 */
+		__sync_synchronize();
+
 		if (args->atomic_cas) {
 			;	/* atomicity is checked at the end of main() */
 		} else if (args->increment && i) {


### PR DESCRIPTION
It's theoretically possible for the core to reorder some instructions
and start loading the source and destination buffers for the
comparison before the work element status is set to complete. The
hardware cannot guess the data dependency if we don't spell it out.

It seems a bit far-fetched here, as it would require some amount of
branch predictions. But it was apparently hit on a slightly simpler
version of this test used by HTX.

Signed-off-by: Frederic Barrat <fbarrat@linux.ibm.com>