### PR TITLE
Makefile: Add override directive to CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include Makefile.vars
 
 OBJS = obj/afu.o obj/internal.o obj/irq.o obj/mmio.o obj/setup.o
 TEST_OBJS = testobj/afu.o testobj/internal.o testobj/irq.o testobj/mmio.o testobj/setup.o
-CFLAGS += -I src/include -I kernel/include -fPIC -D_FILE_OFFSET_BITS=64
+override CFLAGS += -I src/include -I kernel/include -fPIC -D_FILE_OFFSET_BITS=64
 
 VERS_LIB = $(VERSION_MAJOR).$(VERSION_MINOR)
 LIBNAME   = libocxl.so.$(VERS_LIB)


### PR DESCRIPTION
It is perfectly legal to override CFLAGS on the command line,
but this doesn't work with libocxl:

$ make V=1 CFLAGS='-g'
VERSION_MAJOR=1 VERSION_MINOR=1 \
VERSION_PATCH=0 CC="gcc" CFLAGS="-g" \
./version.pl > src/libocxl_info.h
mkdir obj
gcc  -g -c -o obj/afu.o src/afu.c
In file included from src/afu.c:17:
src/libocxl_internal.h:25:10: fatal error: libocxl.h: No such file or directory
   25 | #include "libocxl.h"
      |          ^~~~~~~~~~~
compilation terminated.

This is especially painful for some building frameworks that rely on
that, eg. buildroot.

The GNU make documentation clearly indicates that overriding a variable
on the command line causes ordinary assignments to this variable in the
makefile to be ignored.

Use the override directive so that we can add the required items to
CFLAGS.

https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html#SEC66

Signed-off-by: Greg Kurz <groug@kaod.org>
Reviewed-by: Andrew Donnellan ajd@linux.ibm.com