### PR TITLE
Two commits 4 fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ HAS_WGET = $(shell /bin/which wget > /dev/null 2>&1 && echo y || echo n)
 HAS_CURL = $(shell /bin/which curl > /dev/null 2>&1 && echo y || echo n)
 
 # Update this to test a single feature from the most recent header we require:
-CHECK_OCXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e \\\#include $(1)\\\nvoid test\(struct ocxl_ioctl_features test\)\; | \
+CHECK_OCXL_HEADER_IS_UP_TO_DATE = $(shell /bin/echo -e \#include $(1)\\\nvoid test\(struct ocxl_ioctl_features test\)\; | \
 	$(CC) $(CFLAGS) -Werror -x c -S -o /dev/null - > /dev/null 2>&1 && echo y || echo n)
 
 check_ocxl_header:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ src/libocxl_info.h: version.pl
 	VERSION_MAJOR=${VERSION_MAJOR} VERSION_MINOR=${VERSION_MINOR} \
 	VERSION_PATCH=${VERSION_PATCH} CC="${CC}" CFLAGS="${CFLAGS}" \
 	./version.pl > src/libocxl_info.h
+	cat src/libocxl_info.h
 
 obj:
 	mkdir obj

--- a/version.pl
+++ b/version.pl
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use English;
 use strict;
 use warnings;
 


### PR DESCRIPTION
To avoid make failure on Fedora
start to fail with Rawhide (F33)

* one commit, same failure openSUSE & Fedora need to remove two backslashes
* one commit for Fedora that has reduced packages in build env, w/o perl english package not mandatory for this build.

